### PR TITLE
Fix broken link

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -47,7 +47,7 @@ contentTwoBody = """
 * [**Support both conventional error handling (exceptions) as well as an error-code approach**](https://github.com/simdjson/simdjson/blob/master/doc/basics.md#error-handling): you can compile your C++ code with or without exception support.
 * [**Runtime dispatch**](https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md): the library automatically detects the features supported by the processor. The library runs on all 64-bit systems, but it automagically benefits from advanced processors.
 
-It is found on [Ubuntu](https://packages.ubuntu.com/source/eoan/simdjson) and [Debian](https://packages.debian.org/unstable/source/simdjson), FreeBSD, [MSYS2](https://github.com/simdjson/simdjson/wiki/MSYS2), brew, conan and [vcpkg](https://github.com/simdjson/simdjson/wiki/vcpkg).
+It is found on [Ubuntu](https://packages.ubuntu.com/source/jammy/simdjson) and [Debian](https://packages.debian.org/unstable/source/simdjson), FreeBSD, [MSYS2](https://github.com/simdjson/simdjson/wiki/MSYS2), brew, conan and [vcpkg](https://github.com/simdjson/simdjson/wiki/vcpkg).
 """
 
 

--- a/hugo/content/software.md
+++ b/hugo/content/software.md
@@ -3,7 +3,7 @@ title = "Software"
 layout = "single-para"
 +++
 
- The library is part of major linux distributions like [Ubuntu](https://packages.ubuntu.com/source/eoan/simdjson) and [Debian](https://packages.debian.org/unstable/source/simdjson) and as a FreeBSD package. It is in [Microsoft vcpkg](https://github.com/simdjson/simdjson/wiki/vcpkg). It is available as an [MSYS2 package](https://github.com/simdjson/simdjson/wiki/MSYS2), from [brew](https://formulae.brew.sh/formula/simdjson) and from conan. We publish it as single-header library as well as a CMake build from the[GitHub repository](https://github.com/simdjson/simdjson).
+ The library is part of major linux distributions like [Ubuntu](https://packages.ubuntu.com/source/jammy/simdjson) and [Debian](https://packages.debian.org/unstable/source/simdjson) and as a FreeBSD package. It is in [Microsoft vcpkg](https://github.com/simdjson/simdjson/wiki/vcpkg). It is available as an [MSYS2 package](https://github.com/simdjson/simdjson/wiki/MSYS2), from [brew](https://formulae.brew.sh/formula/simdjson) and from conan. We publish it as single-header library as well as a CMake build from the[GitHub repository](https://github.com/simdjson/simdjson).
 We have a [simdjson organization on GitHub](https://github.com/simdjson).
 
 

--- a/website/index.html
+++ b/website/index.html
@@ -112,7 +112,7 @@
 <li><a href="https://github.com/simdjson/simdjson/blob/master/doc/basics.md#error-handling"><strong>Support both conventional error handling (exceptions) as well as an error-code approach</strong></a>: you can compile your C++ code with or without exception support.</li>
 <li><a href="https://github.com/simdjson/simdjson/blob/master/doc/implementation-selection.md"><strong>Runtime dispatch</strong></a>: the library automatically detects the features supported by the processor. The library runs on all 64-bit systems, but it automagically benefits from advanced processors.</li>
 </ul>
-<p>It is found on <a href="https://packages.ubuntu.com/source/eoan/simdjson">Ubuntu</a> and <a href="https://packages.debian.org/unstable/source/simdjson">Debian</a>, FreeBSD, <a href="https://github.com/simdjson/simdjson/wiki/MSYS2">MSYS2</a>, brew, conan and <a href="https://github.com/simdjson/simdjson/wiki/vcpkg">vcpkg</a>.</p>
+<p>It is found on <a href="https://packages.ubuntu.com/source/jammy/simdjson">Ubuntu</a> and <a href="https://packages.debian.org/unstable/source/simdjson">Debian</a>, FreeBSD, <a href="https://github.com/simdjson/simdjson/wiki/MSYS2">MSYS2</a>, brew, conan and <a href="https://github.com/simdjson/simdjson/wiki/vcpkg">vcpkg</a>.</p>
 		</div>
 	</div>
 	<div  class="wrapper row">

--- a/website/software/index.html
+++ b/website/software/index.html
@@ -89,7 +89,7 @@
 						<div class="wrapper row">
 							<div class="small-12 medium-12 column content-one">
 								<h1>Software</h1>
-								<p> <p>The library is part of major linux distributions like <a href="https://packages.ubuntu.com/source/eoan/simdjson">Ubuntu</a> and <a href="https://packages.debian.org/unstable/source/simdjson">Debian</a> and as a FreeBSD package. It is in <a href="https://github.com/simdjson/simdjson/wiki/vcpkg">Microsoft vcpkg</a>. It is available as an <a href="https://github.com/simdjson/simdjson/wiki/MSYS2">MSYS2 package</a>, from <a href="https://formulae.brew.sh/formula/simdjson">brew</a> and from conan. We publish it as single-header library as well as a CMake build from the<a href="https://github.com/simdjson/simdjson">GitHub repository</a>.
+								<p> <p>The library is part of major linux distributions like <a href="https://packages.ubuntu.com/source/jammy/simdjson">Ubuntu</a> and <a href="https://packages.debian.org/unstable/source/simdjson">Debian</a> and as a FreeBSD package. It is in <a href="https://github.com/simdjson/simdjson/wiki/vcpkg">Microsoft vcpkg</a>. It is available as an <a href="https://github.com/simdjson/simdjson/wiki/MSYS2">MSYS2 package</a>, from <a href="https://formulae.brew.sh/formula/simdjson">brew</a> and from conan. We publish it as single-header library as well as a CMake build from the<a href="https://github.com/simdjson/simdjson">GitHub repository</a>.
 We have a <a href="https://github.com/simdjson">simdjson organization on GitHub</a>.</p>
 <h3 id="quick-start">Quick Start</h3>
 <p>Prerequisites: <code>g++</code> (version 7 or better)  or <code>clang++</code>(version 6 or better), and a 64-bit system (e.g., linux, Windows, FreeBSD, macOS).</p>


### PR DESCRIPTION
Support for Ubuntu 19.10 ("Eoan Ermine") ended in July 2020, and it is no longer listed on the Ubuntu website when searching for packages, so the link for eoan (https://packages.ubuntu.com/source/eoan/simdjson) just shows an error. To fix this, it is replaced by the corresponding link for Ubuntu 22.04 ("Jammy Jellyfish") (https://packages.ubuntu.com/source/jammy/simdjson), the current LTS release supported until April 2027, so the link should keep working for the next few years.